### PR TITLE
:zap: Disable Static Site Generation

### DIFF
--- a/src/app/(home)/about/team/page.tsx
+++ b/src/app/(home)/about/team/page.tsx
@@ -8,8 +8,6 @@ import StandardPageLayout from "@/components/layout/StandardPageLayout";
 import ExecTeam from "./_components/ExecTeam";
 import { teamData } from "./_data/team.data";
 
-export const revalidate = 60;
-
 export default async function TeamPage() {
     let ExecPage = ParsePayloadExecTeam(await getExecPage());
     //if can't find CMS page use hardcoded data

--- a/src/app/(home)/events/_data/events.data.ts
+++ b/src/app/(home)/events/_data/events.data.ts
@@ -12,8 +12,6 @@ export interface Category {
     colors: string;
 }
 
-export const revalidate = 60;
-
 const projects = (await getAllEvents()).map(ParsePayloadEvent);
 
 export const eventsData = {

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -1,10 +1,9 @@
 import type { Metadata } from "next";
-
 import "@/styles/global.css";
-
 import { ReactNode } from "react";
-
 import { figtree } from "@/fonts";
+
+export const dynamic = "force-dynamic";
 
 // SEO
 export const metadata: Metadata = {

--- a/src/app/(home)/projects/all/page.tsx
+++ b/src/app/(home)/projects/all/page.tsx
@@ -8,8 +8,6 @@ import StandardPageLayout from "@/components/layout/StandardPageLayout";
 import ProjectsSection from "../_components/ProjectsSection";
 import { projectsData } from "../_data/projects_data";
 
-export const revalidate = 60;
-
 export default async function ProjectsPage() {
     const projects = (await getAllProjects()).map(ParsePayloadProject);
     const combined = [...projects, ...projectsData] as Project[];


### PR DESCRIPTION
<!-- Please rename the pr title to a descriptive and well-formatted title :)-->

### Description
<!-- Why are you making this change? Give context. What changes did you make?-->

Next.js caching is good but may lead to accidental bugs this close to the release (and hinders previewing payload changes). Ashton found a method to individually disable SSG for each page, but it involved revalidating every 60s, so this disables it entirely across all pages (every request will lead to new database calls and new HTML/JS sent to the client.

We probably want to re-enable this at some point (e.g. keep caching off on staging, but keep caching fully on and require redeploy in prod).

<!-- Close the issue this pr is linked to by typing # and the number of your issue, if it exists-->
Closes #83 

### How To Review
<!-- What (rough) order should the reviewer view your files? -->

N/A

### Notes
<!-- Is there anything else we need to know? Did you do any testing? Are there any risks to this pr? -->

The client cache is still there, so remember to shift + refresh rather than just refresh to revalidate your client cache if you're expecting to see new data :)