### PR TITLE
Remove the learn button to go to role page on project roles

### DIFF
--- a/src/app/(home)/projects/_components/ProjectRoleCard.tsx
+++ b/src/app/(home)/projects/_components/ProjectRoleCard.tsx
@@ -1,15 +1,11 @@
 import React from "react";
 import { tv, VariantProps } from "tailwind-variants";
 
-import { Button } from "@/components/primitives/Button";
-import Link from "next/link";
-import Arrow from "@/assets/svg/Arrow";
-
 // Yes, I know it says "yellow" and the color is bg-orange (not bg-yellow). The yellow is just a bit too bright for this page lol.
 
 const card = tv({
     base: "relative w-full flex flex-col gap-6 overflow-hidden rounded-2xl sm:py-12 sm:px-11 py-9 px-9 " +
-        "transition will-change-auto duration-500 hover:duration-200 hover:-translate-x-1 hover:-translate-y-1 cursor-pointer hover:drop-shadow-cardLift",
+        "transition will-change-auto duration-500 hover:duration-200 hover:-translate-x-1 hover:-translate-y-1 hover:drop-shadow-cardLift",
     variants: {
         color: {
             blue: "bg-blue-100",
@@ -29,15 +25,17 @@ export interface ProjectRoleCardProps {
 }
 
 
-const ProjectRoleCard = ({ variant, title, description, slug, graphic }: ProjectRoleCardProps) => {
+const ProjectRoleCard = ({ variant, title, description, graphic }: ProjectRoleCardProps) => {
     return (
-        <Link className={card({ ...variant })} href={"/projects/roles/" + slug}>
+        <div className={card({ ...variant })}>
             <div className="flex justify-between items-center">
                 <h3 className="text-2xl font-bold text-gray-800 leading-none">{title}</h3>
-                <Button variant={{ style: "tertiary", color: "dark"}} className="min-h-[39px]">
+                {/*
+                <Button variant={{ style: "tertiary", color: "dark" }} className="min-h-[39px]">
                     <span className="hidden sm:inline"> Learn </span>
                     <Arrow></Arrow>
                 </Button>
+                */}
             </div>
             <p className="leading-tight text-md font-normal">{description}</p>
 
@@ -46,7 +44,7 @@ const ProjectRoleCard = ({ variant, title, description, slug, graphic }: Project
                 <p className="text-white">Image or relevant graphic here</p>
                 {graphic}
             </div>
-        </Link>
+        </div>
     );
 };
 


### PR DESCRIPTION
### Description
- commented out the learn button on the project roles page
- made the overall card a `div` instead of a `Link`
- made minimal changes so that this commit is easily reversible

